### PR TITLE
manifest: Track ANT+ repos from LOS 18.1

### DIFF
--- a/lineage.xml
+++ b/lineage.xml
@@ -5,10 +5,11 @@
         revision="lineage-19.0" />
         
 <!-- External repos -->
-  <project path="external/ant-wireless/ant_client" name="android_external_ant-wireless_ant_client" remote="lineage" />
-  <project path="external/ant-wireless/ant_native" name="android_external_ant-wireless_ant_native" remote="lineage" />
-  <project path="external/ant-wireless/ant_service" name="android_external_ant-wireless_ant_service" remote="lineage" />
-  <project path="external/ant-wireless/hidl" name="android_external_ant-wireless_hidl" remote="lineage" />
+  <project path="external/ant-wireless/ant_client" name="android_external_ant-wireless_ant_client" remote="lineage" revision="lineage-18.1" />
+  <project path="external/ant-wireless/ant_native" name="android_external_ant-wireless_ant_native" remote="lineage" revision="lineage-18.1" />
+  <project path="external/ant-wireless/ant_service" name="android_external_ant-wireless_ant_service" remote="lineage" revision="lineage-18.1" />
+  <project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="lineage" revision="lineage-18.1" />
+  <project path="external/ant-wireless/hidl" name="android_external_ant-wireless_hidl" remote="lineage" revision="lineage-18.1" />
 
 <!--  Device Settings  -->
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="lineage" />


### PR DESCRIPTION
 - Currently Los 19 brach repos throw compile errors for legacy devices with old impl
 - Using Los 18.1 brach instead does the trick

Signed-off-by: Pranav Temkar <pranavtemkar@gmail.com>
Change-Id: If0a23410cc53fee6eae11668be59bd8e00f7a2a1