### PR TITLE
manifest: Reenable tracking of CAF guards for MSM8996

### DIFF
--- a/lineage.xml
+++ b/lineage.xml
@@ -42,6 +42,8 @@
     <!-- add guard for AOSP hardware/qcom dir -->
     <linkfile src="os_pickup_aosp.mk" dest="hardware/qcom/Android.mk" />
     <!-- add guards for CAF repositories -->
+    <linkfile src="os_pickup.bp" dest="hardware/qcom-caf/msm8996/Android.bp" />
+    <linkfile src="os_pickup.mk" dest="hardware/qcom-caf/msm8996/Android.mk" />
     <linkfile src="os_pickup.bp" dest="hardware/qcom-caf/msm8998/Android.bp" />
     <linkfile src="os_pickup.mk" dest="hardware/qcom-caf/msm8998/Android.mk" />
     <linkfile src="os_pickup_qssi.bp" dest="hardware/qcom-caf/sdm845/Android.bp" />


### PR DESCRIPTION
 - Legacy devices are still alive

Signed-off-by: Pranav Temkar <pranavtemkar@gmail.com>
Change-Id: Ic1dd6cee56755128c75dc4855571f863a3a0fdf9