### PR TITLE
manifest: Track missing ANT repo from LineageOS

### DIFF
--- a/lineage.xml
+++ b/lineage.xml
@@ -5,9 +5,10 @@
         revision="lineage-20.0" />
 
   <!-- External -->
-  <project path="external/ant-wireless/ant_client" name="android_external_ant-wireless_ant_client" groups="qcom,sdm845" remote="lineage" />
-  <project path="external/ant-wireless/ant_native" name="android_external_ant-wireless_ant_native" groups="qcom,sdm845" remote="lineage" />
-  <project path="external/ant-wireless/ant_service" name="android_external_ant-wireless_ant_service" groups="qcom,sdm845" remote="lineage" />
+  <project path="external/ant-wireless/ant_client" name="android_external_ant-wireless_ant_client" groups="qcom,sdm660" remote="lineage" />
+  <project path="external/ant-wireless/ant_native" name="android_external_ant-wireless_ant_native" groups="qcom,sdm660" remote="lineage" />
+  <project path="external/ant-wireless/ant_service" name="android_external_ant-wireless_ant_service" groups="qcom,sdm660" remote="lineage" />
+  <project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" revision="lineage-19.0" remote="lineage" />
   <project path="external/ant-wireless/hidl" name="android_external_ant-wireless_hidl" groups="qcom,qssi" remote="lineage" />
   <project path="external/exfatprogs" name="android_external_exfatprogs" remote="lineage" />
   <project path="external/gptfdisk" name="android_external_gptfdisk" groups="pdk" remote="lineage" />


### PR DESCRIPTION
 - Some legacy devices need this repo

 - 'external/ant-wireless/antradio-library/com.dsi.ant.antradio_library.xml', needed by '/vendor/etc/permissions/com.dsi.ant.antradio_library.xml', missing and no known rule to make it

 - Also correct the groups as per : https://github.com/LineageOS/android/blob/lineage-20.0/snippets/lineage.xml#L80-L83

Signed-off-by: Pranav Temkar <pranavtemkar@gmail.com>
Change-Id: I6d3cd8369cd25e8985d482b0745e71a308043bb5